### PR TITLE
feat: persinsting theme on localStorage with userPersistentState hook

### DIFF
--- a/src/contexts/theme.tsx
+++ b/src/contexts/theme.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useState, ReactNode, Dispatch, SetStateAction } from 'react'
+import { createContext, useContext, useState, ReactNode, Dispatch, SetStateAction, useEffect } from 'react'
 import { lightTheme, theme } from '../../stitches.config';
+import usePersistentState from '../hooks/persistentState';
 
 type ThemeContextType = {
   currentTheme: any;
@@ -16,9 +17,20 @@ type ThemeProviderProps = {
 export function ThemeProvider({
   children,
 }: ThemeProviderProps){
-  const [currentTheme, setCurrentTheme] = useState(theme);
-  // @ts-ignore
-  const toggleTheme = () => setCurrentTheme(currentTheme === lightTheme ? theme : lightTheme);
+  const [currentThemeName, setCurrentThemeName] = usePersistentState('ThemeContext#currentThemeName', theme.className)
+  const [currentTheme, setCurrentTheme] = useState(theme)
+
+  useEffect(() => {
+    // @ts-ignore
+    const themes: {[key: string]: typeof theme} = {
+      [theme.className]: theme,
+      [lightTheme.className]: lightTheme,
+    }
+
+    setCurrentTheme(themes[currentThemeName] as typeof theme);
+  }, [currentThemeName])
+
+  const toggleTheme = () => setCurrentThemeName(currentTheme === theme ? lightTheme.className : theme.className);
 
   return (
     <ThemeContext.Provider

--- a/src/hooks/persistentState.ts
+++ b/src/hooks/persistentState.ts
@@ -1,0 +1,36 @@
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+
+function usePersistentState<T>(key: string, defaultValue: T): [T, (value: T) => Dispatch<SetStateAction<T>>] {
+  const [state, setState] = useState<T>(defaultValue);
+
+  useEffect(() => {
+    const cachedValue = localStorage.getItem(key);
+
+    if (cachedValue) setState(JSON.parse(cachedValue) as T);
+  }, [key])
+
+  const persistentSet = (value: T): Dispatch<SetStateAction<T>> => {
+    localStorage.setItem(key, JSON.stringify(value, getCircularReplacer()));
+    setState(value)
+
+    return setState;
+  }
+
+  return [state, persistentSet];
+}
+
+const getCircularReplacer = () => {
+  const seen = new WeakSet();
+  return (key: string, value: any) => {
+    if (typeof value === "object" && value !== null) {
+      if (seen.has(value)) {
+        return;
+      }
+      seen.add(value);
+    }
+    return value;
+  };
+};
+
+
+export default usePersistentState;


### PR DESCRIPTION
# [FEAT] Theme switch persistence
Saving selected theme on localStorage with ```usePersistentState``` hook

# Changelog

## Added
- ```usePersistentState``` hook to save/load state from localStorage

## Modified
- Saving selected theme on localStorage